### PR TITLE
Added support for playbooks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,9 @@ dist_dependent_files := \
 example_role_dirs := $(wildcard examples/roles/*)
 example_role_md_files := $(patsubst examples/roles/%,examples/output/%.md,$(example_role_dirs))
 example_role_rst_files := $(patsubst examples/roles/%,examples/output/%.rst,$(example_role_dirs))
+example_playbook_files := $(wildcard examples/playbooks/*)
+example_playbook_md_files := $(patsubst examples/playbooks/%.specs.yml,examples/output/%.md,$(example_playbook_files))
+example_playbook_rst_files := $(patsubst examples/playbooks/%.specs.yml,examples/output/%.rst,$(example_playbook_files))
 
 # Directory for .done files
 done_dir := done
@@ -261,14 +264,20 @@ all: install develop check ruff pylint bandit build authors
 	@echo "Makefile: $@ done."
 
 .PHONY: examples
-examples: $(example_role_md_files) $(example_role_rst_files)
+examples: $(example_role_md_files) $(example_role_rst_files) $(example_playbook_md_files) $(example_playbook_rst_files)
 	@echo "Makefile: $@ done."
 
 examples/output/%.md: examples/roles/%/meta/argument_specs.yml $(package_dir)/templates/role.md.j2 $(done_dir)/install_$(pymn).done
-	ansible-doc-template-extractor --format md --out-dir examples/output $<
+	ansible-doc-template-extractor -v --format md --out-dir examples/output $<
 
 examples/output/%.rst: examples/roles/%/meta/argument_specs.yml $(package_dir)/templates/role.rst.j2 $(done_dir)/install_$(pymn).done
-	ansible-doc-template-extractor --format rst --out-dir examples/output $<
+	ansible-doc-template-extractor -v --format rst --out-dir examples/output $<
+
+examples/output/%.md: examples/playbooks/%.specs.yml $(package_dir)/templates/playbook.md.j2 $(done_dir)/install_$(pymn).done
+	ansible-doc-template-extractor -v --format md --out-dir examples/output $<
+
+examples/output/%.rst: examples/playbooks/%.specs.yml $(package_dir)/templates/playbook.rst.j2 $(done_dir)/install_$(pymn).done
+	ansible-doc-template-extractor -v --format rst --out-dir examples/output $<
 
 .PHONY: release_branch
 release_branch:

--- a/README.md
+++ b/README.md
@@ -1,21 +1,31 @@
-# ansible-doc-template-extractor
+# Ansible Documentation Template Extractor
 
-**ansible-doc-template-extractor** is a documentation extractor that supports
-the format Ansible roles use in their `meta/argument_specs.yml` files as input,
-and arbitrary Jinja2 template files to control what is generated as output.
+**ansible-doc-template-extractor** is a documentation extractor for Ansible that
+reads the documentation from spec files in YAML format and produces
+documentation output using Jinja2 template files.
 
-It can also be used for Ansible playbooks (and other Ansible items), as long as
-a spec file in YAML format is provided that documents it. The format can differ
-from the argument spec files for roles, but of course the template file needs
-to support the format of the spec file.
+The supported formats of the spec files are:
+* For Ansible roles, the Ansible-defined format in the
+  `<role>/meta/argument_specs.yml` files
+  (see [here](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_reuse_roles.html#specification-format)).
+* For Ansible playbooks, a format defined by this project (see below).
+* You can also use any other spec file format for roles, playbooks or any other
+  Ansible items, as long as it is in YAML and you provide a custom template
+  for it.
 
-The format of the spec files for Ansible roles is described here:
-https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_reuse_roles.html#specification-format
+The ansible-doc-template-extractor program includes a number of built-in
+template files:
 
-Template files for RST and Markdown format for the spec files for Ansible roles
-are included with the ansible-doc-template-extractor package. You can write your
-own templates for other formats or for Ansible playbooks (and other Ansible
-items).
+* role.rst.j2: Produces RST format from the Ansible-defined spec files for roles.
+* role.md.j2: Produces Markdown format from the Ansible-defined spec files for roles.
+* playbook.rst.j2: Produces RST format from the project-defined spec files for playbooks.
+* playbook.md.j2: Produces Markdown format from the project-defined spec files for playbooks.
+
+These templates are selected automatically based on the detected spec file type
+and output format.
+
+You can write your own custom templates for other output formats and/or
+other spec file formats (see below).
 
 Disclaimer: The ansible-doc-template-extractor tool should be seen as a
 temporary bridge until there is official documentation extraction support for
@@ -66,6 +76,7 @@ Then you can run the extractor as follows:
 $ ansible-doc-template-extractor -v -o docs my_collection/roles/my_role/meta/argument_specs.yml
 
 Loading template file: .../templates/role.rst.j2
+Ansible spec type: role
 Ansible name: my_role
 Loading spec file: my_collection/roles/my_role/meta/argument_specs.yml
 Created output file: docs/my_role.md
@@ -84,13 +95,39 @@ Display the help message to learn about other options:
 $ ansible-doc-template-extractor --help
 ```
 
-# Writing templates
+# Format of spec file for Ansible playbooks
 
-The template files for roles and for the RST and Markdown formats are included
-with the installed ansible-doc-template-extractor package.
+Note: This spec file format is preliminary at this point and can still change.
 
-You can write your own templates for any other format or for Ansible playbooks
-(or other Ansible items).
+The spec file format defined by this project for Ansible playbooks:
+
+```
+playbook:
+  name: <Playbook name>
+  title: <Playbook title>
+  description:
+    <string or list of strings with playbook descriptions>
+  prerequisites:
+    <string or list of strings with playbook prerequisites>
+  version_added: <If the playbook was added to Ansible, the Ansible version>
+  examples:
+    - description: <string or list of strings with example description>
+      command: <example ansible-playbook command>
+  input_schema:
+    <A JSON schema that describes a single input variable of the playbook>
+  output_schema:
+    <A JSON schema that describes a single output variable for success>
+  authors:
+    - <list of strings with playbook author names>
+```
+
+An example spec file for playbooks using this format is in the
+[examples/playbooks](examples/playbooks) directory.
+
+# Writing custom templates
+
+You can write your own custom templates for any other output format and/or for
+any other spec file format.
 
 The following rules apply when writing templates:
 
@@ -112,11 +149,15 @@ The following rules apply when writing templates:
 
 * The following Jinja2 variables are set for use by the template:
 
-  - **name** (str): Name of the Ansible role or playbook.
+  - **name** (str): Name of the Ansible role, playbook, or other item.
 
   - **spec_file_name** (str): Path name of the spec file.
 
   - **spec_file_dict** (dict): Content of the spec file.
+
+You can use the templates in the
+[templates](src/ansible_doc_template_extractor/templates)
+directory as examples for your own custom templates.
 
 # Reporting issues
 

--- a/examples/output/role_with_inparams.md
+++ b/examples/output/role_with_inparams.md
@@ -84,4 +84,3 @@ Their values are the names of variables to be set upon return from the role\.
 ## Authors
 
 * Andreas Maier
-

--- a/examples/output/role_with_inparams.rst
+++ b/examples/output/role_with_inparams.rst
@@ -91,4 +91,3 @@ Authors
 -------
 
 * Andreas Maier
-

--- a/examples/output/xyz_upgrade.md
+++ b/examples/output/xyz_upgrade.md
@@ -1,0 +1,90 @@
+# Playbook xyz_upgrade -- Upgrade XYZ container to a new version
+
+## Synopsis
+
+This playbook upgrades an XYZ container to a new version\.
+
+
+
+## Prerequisites
+
+From where the playbook is run\, there is network connectivity to the server running the XYZ container\.
+
+
+
+## Version added
+
+1.17
+
+## Input Parameters
+
+Playbook input variable \'params\'\.
+
+
+
+* **server** (string):
+
+  IP address or hostname of the server that runs the XYZ container\.
+
+
+  Required\.
+
+* **version** (string):
+
+  Desired new version of the XYZ container\.
+
+
+  Required\.
+
+* **foo_object** (object):
+
+  Demonstrate nested objects
+
+
+  Optional\.
+
+  * **bar** (string):
+
+    The bar\.
+
+
+    Required\.
+
+
+
+* **foo_array** (list of object):
+
+  Demonstrate nested array of objects
+
+
+  Optional\.
+
+  * **bar** (string):
+
+    The bar\.
+
+
+    Required\.
+
+
+
+
+
+## Output Parameters
+
+Playbook output variable \'output\'\, in case of success\.
+
+
+
+* **previous_version** (string):
+
+  Version of the XYZ container before the upgrade\.
+
+
+  Required\.
+
+
+
+## Authors
+
+* Andreas Maier

--- a/examples/output/xyz_upgrade.rst
+++ b/examples/output/xyz_upgrade.rst
@@ -1,0 +1,99 @@
+.. _xyz_upgrade_playbook:
+
+Playbook xyz_upgrade -- Upgrade XYZ container to a new version
+==============================================================
+
+Synopsis
+--------
+
+This playbook upgrades an XYZ container to a new version.
+
+
+
+Prerequisites
+-------------
+
+From where the playbook is run, there is network connectivity to the server running the XYZ container.
+
+
+
+Version added
+-------------
+
+1.17
+
+Input Parameters
+----------------
+
+Playbook input variable 'params'.
+
+
+
+* **server** (string):
+
+  IP address or hostname of the server that runs the XYZ container.
+
+
+  Required.
+
+* **version** (string):
+
+  Desired new version of the XYZ container.
+
+
+  Required.
+
+* **foo_object** (object):
+
+  Demonstrate nested objects
+
+
+  Optional.
+
+  * **bar** (string):
+
+    The bar.
+
+
+    Required.
+
+
+
+* **foo_array** (list of object):
+
+  Demonstrate nested array of objects
+
+
+  Optional.
+
+  * **bar** (string):
+
+    The bar.
+
+
+    Required.
+
+
+
+
+
+Output Parameters
+-----------------
+
+Playbook output variable 'output', in case of success.
+
+
+
+* **previous_version** (string):
+
+  Version of the XYZ container before the upgrade.
+
+
+  Required.
+
+
+
+Authors
+-------
+
+* Andreas Maier

--- a/examples/playbooks/xyz_upgrade.specs.yml
+++ b/examples/playbooks/xyz_upgrade.specs.yml
@@ -1,0 +1,64 @@
+# Spec file format for Ansible playbooks, defined by the ansible-doc-template-extractor project.
+playbook:
+  name: xyz_upgrade
+  title: Upgrade XYZ container to a new version
+  description:
+    - This playbook upgrades an XYZ container to a new version.
+  prerequisites:
+    - From where the playbook is run, there is network connectivity to the
+      server running the XYZ container.
+  version_added: "1.17"
+  examples:
+    - description: Upgrade the XYZ container to a specified version
+      command: |
+        ansible-playbook xyz_upgrade -e '{"params": {"server": "10.11.12.13", "version": "1.8.0"}}'
+  input_schema:
+    # JSON schema
+    description: Playbook input variable 'params'.
+    type: object
+    additionalProperties: false
+    required:
+      - server
+      - version
+    properties:
+      server:
+        description: IP address or hostname of the server that runs the XYZ container.
+        type: string
+      version:
+        description: Desired new version of the XYZ container.
+        type: string
+      foo_object:
+        description: Demonstrate nested objects
+        type: object
+        additionalProperties: false
+        required:
+          - bar
+        properties:
+          bar:
+            description: The bar.
+            type: string
+      foo_array:
+        description: Demonstrate nested array of objects
+        type: array
+        items:
+          type: object
+          additionalProperties: false
+          required:
+            - bar
+          properties:
+            bar:
+              description: The bar.
+              type: string
+  output_schema:
+    # JSON schema
+    description: Playbook output variable 'output', in case of success.
+    type: object
+    additionalProperties: false
+    required:
+      - previous_version
+    properties:
+      previous_version:
+        description: Version of the XYZ container before the upgrade.
+        type: string
+  authors:
+    - Andreas Maier

--- a/examples/roles/role_with_inparams/meta/argument_specs.yml
+++ b/examples/roles/role_with_inparams/meta/argument_specs.yml
@@ -1,15 +1,4 @@
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
----
+# Spec file format for Ansible roles, defined by Ansible (<role>/meta/argument_specs.yml files)
 argument_specs:
   main:
     short_description:

--- a/src/ansible_doc_template_extractor/templates/playbook.md.j2
+++ b/src/ansible_doc_template_extractor/templates/playbook.md.j2
@@ -1,0 +1,109 @@
+{#
+ # Template for Ansible playbooks that have a spec file for use with ansible-doc-template-extractor.
+ # This template produces an .md file.
+ # For the input variables that are set, run: ansible-doc-template-extractor --help-template.
+ #}
+{% macro para_generation(paras, level) %}
+{# Macro that generates a list of paragraphs #}
+{% if paras is string %}
+{{ "  " * level }}{{ paras | to_md }}
+
+{% elif paras is iterable %}
+{%   for para in paras %}
+{{ "  " * level }}{{ para | to_md }}
+
+{%   endfor %}
+{% else %}
+{{ "  " * level }}{{ para | to_md }}
+{% endif %}
+{% endmacro %}
+{% macro schema_generation(obj, level) %}
+{# Macro that generates a list of properties defined in an object within a JSON schema, recursively #}
+{%   for name, spec in obj.properties.items() if not name.startswith('_') %}
+{%     set required = name in obj.required %}
+{%     if required %}
+{%       set required_txt = "Required." %}
+{%     elif spec.default is defined %}
+{%       set required_txt = "Optional, default: {}.".format(spec.default) %}
+{%     else %}
+{%       set required_txt = "Optional." %}
+{%     endif %}
+{%     if spec.type == 'array' %}
+{%       if spec.__getitem__('items') is defined %}
+{%         set type_txt = "list of {}".format(spec.__getitem__('items').type) %}
+{%       else %}
+{%         set type_txt = "list" %}
+{%       endif %}
+{%     else %}
+{%       set type_txt = spec.type %}
+{%     endif %}
+{%     if spec.enum is defined %}
+{%       set choices_txt = "Choices: {}.".format(spec.enum | join(', ')) %}
+{%     else %}
+{%       set choices_txt = "" %}
+{%     endif %}
+{{ "  " * level }}* **{{ name }}** ({{ type_txt }}):
+
+{{ para_generation(spec.description, level + 1) }}
+{{ "  " * level }}  {{ required_txt | to_md }}
+{%     if spec.choices is defined %}
+
+{{ "  " * level }}  {{ choices_txt | to_md }}
+{%     endif %}
+{%     if spec.type == 'array' and spec.__getitem__('items') is defined %}
+
+{{ schema_generation(spec.__getitem__('items'), level + 1) }}
+{%     elif spec.type == 'object' and spec.properties is defined %}
+
+{{ schema_generation(spec, level + 1) }}
+{%     endif %}
+
+{%   endfor %}
+{% endmacro %}
+{% set playbook_dict = spec_file_dict.playbook %}
+{% set title = "Playbook {} -- {}".format(name, playbook_dict.title) %}
+# {{ title }}
+
+## Synopsis
+
+{{ para_generation(playbook_dict.description, 0) }}
+{% if playbook_dict.prerequisites is defined %}
+
+## Prerequisites
+
+{{ para_generation(playbook_dict.prerequisites, 0) }}
+{% endif %}
+{% if playbook_dict.version_added is defined %}
+
+## Version added
+
+{{ playbook_dict.version_added }}
+{% endif %}
+{% if playbook_dict.input_schema is defined %}
+
+## Input Parameters
+
+{%   if playbook_dict.input_schema.description is defined %}
+{{ para_generation(playbook_dict.input_schema.description, 0) }}
+
+{%   endif %}
+{{ schema_generation(playbook_dict.input_schema, 0) }}
+{% endif %}
+{% if playbook_dict.input_schema is defined %}
+
+## Output Parameters
+
+{%   if playbook_dict.output_schema.description is defined %}
+{{ para_generation(playbook_dict.output_schema.description, 0) }}
+
+{%   endif %}
+{{ schema_generation(playbook_dict.output_schema, 0) }}
+{% endif %}
+{% if playbook_dict.authors is defined %}
+
+## Authors
+
+{%   for author in playbook_dict.authors %}
+* {{ author }}
+{%   endfor %}
+{% endif %}

--- a/src/ansible_doc_template_extractor/templates/playbook.rst.j2
+++ b/src/ansible_doc_template_extractor/templates/playbook.rst.j2
@@ -1,0 +1,118 @@
+{#
+ # Template for Ansible playbooks that have a spec file for use with ansible-doc-template-extractor.
+ # This template produces an .rst file.
+ # For the input variables that are set, run: ansible-doc-template-extractor --help-template.
+ #}
+{% macro para_generation(paras, level) %}
+{# Macro that generates a list of paragraphs #}
+{% if paras is string %}
+{{ "  " * level }}{{ paras | to_rst }}
+
+{% elif paras is iterable %}
+{%   for para in paras %}
+{{ "  " * level }}{{ para | to_rst }}
+
+{%   endfor %}
+{% else %}
+{{ "  " * level }}{{ para | to_rst }}
+{% endif %}
+{% endmacro %}
+{% macro schema_generation(obj, level) %}
+{# Macro that generates a list of properties defined in an object within a JSON schema, recursively #}
+{%   for name, spec in obj.properties.items() if not name.startswith('_') %}
+{%     set required = name in obj.required %}
+{%     if required %}
+{%       set required_txt = "Required." %}
+{%     elif spec.default is defined %}
+{%       set required_txt = "Optional, default: {}.".format(spec.default) %}
+{%     else %}
+{%       set required_txt = "Optional." %}
+{%     endif %}
+{%     if spec.type == 'array' %}
+{%       if spec.__getitem__('items') is defined %}
+{%         set type_txt = "list of {}".format(spec.__getitem__('items').type) %}
+{%       else %}
+{%         set type_txt = "list" %}
+{%       endif %}
+{%     else %}
+{%       set type_txt = spec.type %}
+{%     endif %}
+{%     if spec.enum is defined %}
+{%       set choices_txt = "Choices: {}.".format(spec.enum | join(', ')) %}
+{%     else %}
+{%       set choices_txt = "" %}
+{%     endif %}
+{{ "  " * level }}* **{{ name }}** ({{ type_txt }}):
+
+{{ para_generation(spec.description, level + 1) }}
+{{ "  " * level }}  {{ required_txt | to_rst }}
+{%     if spec.choices is defined %}
+
+{{ "  " * level }}  {{ choices_txt | to_rst }}
+{%     endif %}
+{%     if spec.type == 'array' and spec.__getitem__('items') is defined %}
+
+{{ schema_generation(spec.__getitem__('items'), level + 1) }}
+{%     elif spec.type == 'object' and spec.properties is defined %}
+
+{{ schema_generation(spec, level + 1) }}
+{%     endif %}
+
+{%   endfor %}
+{% endmacro %}
+{% set playbook_dict = spec_file_dict.playbook %}
+.. _{{ name }}_playbook:
+
+{% set title = "Playbook {} -- {}".format(name, playbook_dict.title) %}
+{{ title }}
+{{ '=' * title | length }}
+
+Synopsis
+--------
+
+{{ para_generation(playbook_dict.description, 0) }}
+{% if playbook_dict.prerequisites is defined %}
+
+Prerequisites
+-------------
+
+{{ para_generation(playbook_dict.prerequisites, 0) }}
+{% endif %}
+{% if playbook_dict.version_added is defined %}
+
+Version added
+-------------
+
+{{ playbook_dict.version_added }}
+{% endif %}
+{% if playbook_dict.input_schema is defined %}
+
+Input Parameters
+----------------
+
+{%   if playbook_dict.input_schema.description is defined %}
+{{ para_generation(playbook_dict.input_schema.description, 0) }}
+
+{%   endif %}
+{{ schema_generation(playbook_dict.input_schema, 0) }}
+{% endif %}
+{% if playbook_dict.input_schema is defined %}
+
+Output Parameters
+-----------------
+
+{%   if playbook_dict.output_schema.description is defined %}
+{{ para_generation(playbook_dict.output_schema.description, 0) }}
+
+{%   endif %}
+{{ schema_generation(playbook_dict.output_schema, 0) }}
+{% endif %}
+{% if playbook_dict.authors is defined %}
+
+Authors
+-------
+
+{%   for author in playbook_dict.authors %}
+* {{ author }}
+{%   endfor %}
+{% endif %}

--- a/src/ansible_doc_template_extractor/templates/role.md.j2
+++ b/src/ansible_doc_template_extractor/templates/role.md.j2
@@ -92,6 +92,5 @@
 
 {%   for author in role_dict.author %}
 * {{ author }}
-
 {%   endfor %}
 {% endfor %}

--- a/src/ansible_doc_template_extractor/templates/role.rst.j2
+++ b/src/ansible_doc_template_extractor/templates/role.rst.j2
@@ -101,6 +101,5 @@ Authors
 
 {%   for author in role_dict.author %}
 * {{ author }}
-
 {%   endfor %}
 {% endfor %}


### PR DESCRIPTION
Details:

* Added new templates playbook.rst.j2 and playbook.md.j2.

* Added a new --type/-t option that can specify the Ansible spec file type: role, playbook, other. It is optional and the spec file type is detected by default from the spec file name.

* Because the short option -t is not used for --type, it has been removed from --template, which is a less commonly used option.

* The --name option is now required also for type=other.

* Added a new --help-playbook-spec option that displays help for the format of the playbook spec files.

* Added an example spec file for a playbook.