### PR TITLE
Improved playbook and role doc templates

### DIFF
--- a/examples/output/xyz_upgrade_options.md
+++ b/examples/output/xyz_upgrade_options.md
@@ -48,6 +48,9 @@ Permissions\.
 
 
   Optional\.
+
+  Dict items:
+
   * **bar** (str):
 
     The bar\.
@@ -63,6 +66,9 @@ Permissions\.
 
 
   Optional\.
+
+  Dict items:
+
   * **bar** (str):
 
     The bar\.

--- a/examples/output/xyz_upgrade_options.rst
+++ b/examples/output/xyz_upgrade_options.rst
@@ -56,6 +56,9 @@ Input Parameters
 
 
   Optional.
+
+  Dict items:
+
   * **bar** (str):
 
     The bar.
@@ -71,6 +74,9 @@ Input Parameters
 
 
   Optional.
+
+  Dict items:
+
   * **bar** (str):
 
     The bar.

--- a/src/ansible_doc_template_extractor/templates/playbook.md.j2
+++ b/src/ansible_doc_template_extractor/templates/playbook.md.j2
@@ -54,6 +54,9 @@
 {{ "  " * level }}  {{ choices_txt | to_md }}
 {%     endif %}
 {%     if spec.options is defined %}
+
+{{ "  " * level }}  Dict items:
+
 {{ option_generation(spec.options, level + 1) }}
 {%     endif %}
 

--- a/src/ansible_doc_template_extractor/templates/playbook.rst.j2
+++ b/src/ansible_doc_template_extractor/templates/playbook.rst.j2
@@ -54,6 +54,9 @@
 {{ "  " * level }}  {{ choices_txt | to_rst }}
 {%     endif %}
 {%     if spec.options is defined %}
+
+{{ "  " * level }}  Dict items:
+
 {{ option_generation(spec.options, level + 1) }}
 {%     endif %}
 

--- a/src/ansible_doc_template_extractor/templates/role.md.j2
+++ b/src/ansible_doc_template_extractor/templates/role.md.j2
@@ -54,6 +54,9 @@
 {{ "  " * level }}  {{ choices_txt | to_md }}
 {%     endif %}
 {%     if spec.options is defined %}
+
+{{ "  " * level }}  Dict items:
+
 {{ option_generation(spec.options, level + 1) }}
 {%     endif %}
 

--- a/src/ansible_doc_template_extractor/templates/role.rst.j2
+++ b/src/ansible_doc_template_extractor/templates/role.rst.j2
@@ -54,6 +54,9 @@
 {{ "  " * level }}  {{ choices_txt | to_rst }}
 {%     endif %}
 {%     if spec.options is defined %}
+
+{{ "  " * level }}  Dict items:
+
 {{ option_generation(spec.options, level + 1) }}
 {%     endif %}
 


### PR DESCRIPTION
Details:

* The Jinja2 template files had the issue that sub-options were added without an empty line in the generated RSTi/MD, so that they were joined into one line in the HTML created by Sphinx.

  This change adds an empty line before any sub-options and the text 'Dict items:', to make it more explicit that they are sub-options.