### PR TITLE
Relaxed escaping in to_rst/to_md filters

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,6 +2,8 @@
 max_line_length = 80
 
 ignore =
+    W503
+    W504
 
 exclude =
     .git,

--- a/examples/output/xyz_upgrade_options.md
+++ b/examples/output/xyz_upgrade_options.md
@@ -9,6 +9,11 @@
 This playbook upgrades an XYZ container to a new version\.
 
 
+An example list\:
+\* item 1
+\* item 2
+
+
 No version check is performed\, this playbook simply replaces the container\.
 
 

--- a/examples/output/xyz_upgrade_options.rst
+++ b/examples/output/xyz_upgrade_options.rst
@@ -14,6 +14,13 @@ Synopsis
 This playbook upgrades an XYZ container to a new version.
 
 
+An example list:
+
+* item 1
+
+* item 2
+
+
 No version check is performed, this playbook simply replaces the container.
 
 

--- a/examples/playbooks/xyz_upgrade_options.meta.yml
+++ b/examples/playbooks/xyz_upgrade_options.meta.yml
@@ -4,6 +4,10 @@ argument_specs:
     short_description: Upgrade XYZ container to a new version (Ansible options format)
     description:
       - This playbook upgrades an XYZ container to a new version.
+      - |
+        An example list:
+        * item 1
+        * item 2
       - No version check is performed, this playbook simply replaces the container.
     requirements:
       - From where the playbook is run, there is network connectivity to the

--- a/tests/unit/test_to_md_filter.py
+++ b/tests/unit/test_to_md_filter.py
@@ -131,23 +131,23 @@ TESTCASES_TO_MD_FILTER = [
         None
     ),
     (
-        "Asterisk list chars are escaped",
+        "Asterisk list chars are preserved",
         "* List item 1",
-        "\\* List item 1",
+        "* List item 1",
         None,
         None
     ),
     (
-        "Dash list chars are escaped",
+        "Dash list chars are preserved",
         "- List item 1",
-        "\\- List item 1",
+        "- List item 1",
         None,
         None
     ),
     (
-        "Number list chars are escaped",
+        "Number list chars are preserved",
         "# List item 1",
-        "\\# List item 1",
+        "# List item 1",
         None,
         None
     ),

--- a/tests/unit/test_to_rst_filter.py
+++ b/tests/unit/test_to_rst_filter.py
@@ -131,16 +131,16 @@ TESTCASES_TO_RST_FILTER = [
         None
     ),
     (
-        "Asterisk list chars are escaped",
+        "Asterisk list chars are preserved",
         "* List item 1",
-        "\\* List item 1",
+        "* List item 1",
         None,
         None
     ),
     (
-        "Dash list chars are escaped",
+        "Dash list chars are preserved",
         "- List item 1",
-        "\\- List item 1",
+        "- List item 1",
         None,
         None
     ),
@@ -182,28 +182,34 @@ TESTCASES_TO_RST_FILTER = [
     (
         "Ansible markup HORIZONTALLINE is processed",
         "The quick brown fox HORIZONTALLINE jumps over the lazy dog",
-        "The quick brown fox\n\n------------\n\njumps over the lazy dog",
+        "The quick brown fox\n"
+        "\n"
+        ".. raw:: html\n"
+        "\n"
+        "  <hr>\n"
+        "\n"
+        "jumps over the lazy dog",
         None,
         None
     ),
     (
         "Ansible markup O() is processed",
         "For O(state=present) the",
-        "For :literal:`state=present` the",
+        "For :ansopt:`state=present` the",
         None,
         None
     ),
     (
         "Ansible markup V() is processed",
         "Value V(blue) is",
-        "Value :literal:`blue` is",
+        "Value :ansval:`blue` is",
         None,
         None
     ),
     (
         "Ansible markup RV() is processed",
         "Return value RV(color=blue) is",
-        "Return value :literal:`color=blue` is",
+        "Return value :ansretval:`color=blue` is",
         None,
         None
     ),


### PR DESCRIPTION
Details:

* Description lines that start with *, - or # are no longer backslash-escaped. This allows to have bullet or numbered lists in the description strings.

* For RST generation, the to_rst() function is now used instead of to_rst_plain(). This preserves more of the original markup and uses richer RST roles. These RST roles require that the Sphinx extension 'sphinx_antsibull_ext' is used, which is provided by the antsibull-docs Python package.